### PR TITLE
Adding support for multi volumes single tag

### DIFF
--- a/brep_part_finder/core.py
+++ b/brep_part_finder/core.py
@@ -1,4 +1,5 @@
 import warnings
+from collections.abc import Iterable
 from typing import Tuple
 
 import numpy as np
@@ -171,7 +172,7 @@ def get_dict_of_part_ids(
                 raise ValueError(f"multiple matching volumes were found for {key}")
             # todo check that key is not already in use
             key_and_part_id[matching_part_id[0]] = key
-        else:
+        elif isinstance(value, Iterable):
             # assumed to be list
             for entry in value:
                 # check if value is a list of dictionaries or a dictionary
@@ -186,5 +187,7 @@ def get_dict_of_part_ids(
                     raise ValueError(f"multiple matching volumes were found for {key}")
                 # todo check that key is not already in use
                 key_and_part_id[matching_part_id[0]] = key
-
+        else:
+            msg = "dictionary values must be either a dictionary or a list of dictionaries"
+            raise ValueError(msg)
     return key_and_part_id

--- a/brep_part_finder/core.py
+++ b/brep_part_finder/core.py
@@ -157,14 +157,34 @@ def get_dict_of_part_ids(
 ):
     key_and_part_id = {}
     for key, value in shape_properties.items():
-        matching_part_id = get_part_id(
-            brep_part_properties=brep_part_properties,
-            volume_atol=volume_atol,
-            center_atol=center_atol,
-            bounding_box_atol=bounding_box_atol,
-            **value,
-        )
-        if len(matching_part_id) > 1:
-            raise ValueError(f"multiple matching volumes were found for {key}")
-        key_and_part_id[matching_part_id[0]] = key
+
+        if isinstance(value, dict):
+            # check if value is a list of dictionaries or a dictionary
+            matching_part_id = get_part_id(
+                brep_part_properties=brep_part_properties,
+                volume_atol=volume_atol,
+                center_atol=center_atol,
+                bounding_box_atol=bounding_box_atol,
+                **value,
+            )
+            if len(matching_part_id) > 1:
+                raise ValueError(f"multiple matching volumes were found for {key}")
+            # todo check that key is not already in use
+            key_and_part_id[matching_part_id[0]] = key
+        else:
+            # assumed to be list
+            for entry in value:
+                # check if value is a list of dictionaries or a dictionary
+                matching_part_id = get_part_id(
+                    brep_part_properties=brep_part_properties,
+                    volume_atol=volume_atol,
+                    center_atol=center_atol,
+                    bounding_box_atol=bounding_box_atol,
+                    **entry,
+                )
+                if len(matching_part_id) > 1:
+                    raise ValueError(f"multiple matching volumes were found for {key}")
+                # todo check that key is not already in use
+                key_and_part_id[matching_part_id[0]] = key
+
     return key_and_part_id

--- a/examples/paramak_example.py
+++ b/examples/paramak_example.py
@@ -1,24 +1,18 @@
+import json
+import os
+
 import brep_part_finder as bpf
 import paramak
-import json
 
 my_reactor = paramak.BallReactor()
-# known details (volume, center, bounding box when CAD is created)
-# printed using json dumps to make it more human readable
-print(json.dumps(my_reactor.part_properties, indent=4))
 
 # order of parts gets mixed when saved to brep file
-my_reactor.export_brep("my_reactor.brep")
-
-# brep file is imported
-my_brep_part_properties = bpf.get_brep_part_properties("my_reactor.brep")
-
-# request to find part ids that are mixed up in the Brep file
-# using the volume, center, bounding box that we know about when creating the
-# CAD geometry in the first place
-key_and_part_id = bpf.get_dict_of_part_ids(
-    brep_part_properties=my_brep_part_properties,
-    shape_properties=my_reactor.part_properties,
+my_reactor.export_dagmc_h5m(
+    filename='dagmc.h5m',
+    min_mesh_size=1,
+    max_mesh_size=3,
+    exclude=['plasma']  # does not mesh the plasma as not many neutron interactions occur
 )
 
-print(key_and_part_id)
+# converting for viewing geometry in Paraview / Visit
+os.system('mbconvert dagmc.h5m dagm.vtk')

--- a/examples/paramak_example.py
+++ b/examples/paramak_example.py
@@ -1,7 +1,6 @@
-import json
+
 import os
 
-import brep_part_finder as bpf
 import paramak
 
 my_reactor = paramak.BallReactor()


### PR DESCRIPTION
To allow the same tag to be applied to multiple volumes some changes were made

The shape_properties now allows entries to be a list of dictionaries in addition to a single dictionary