### PR TITLE
added ==master for cadquery

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python {{ python }}
     - setuptools
   run:
-    - cadquery
+    - cadquery==master
     - numpy
 
 test:
@@ -25,11 +25,11 @@ test:
     - brep_part_finder
   requires:
     - pytest
-  # source_files:
-  #   - tests/
-  #   - examples/
-  # commands:
-  #   - pytest tests
+  source_files:
+    - tests/
+    - examples/
+  commands:
+    - pytest tests
 
 
 about:


### PR DESCRIPTION
This is a fix that allows the conda build for this package to target cadquery master instead of the current stable release (cadquery 2.1)

There are a few gotchas I fell into when making this package

First the channel order is important, as cadquery 1 exists on conda-forge and cadquery exists on channel cadquery it is important to put ```-c cadquery -c conda-forge``` in this order.

Secondly I had specified cadquery master in the [conda_build_config.yml](https://github.com/fusion-energy/brep_part_finder/blob/bdcb77d92e2f934937480b50711a1e7d6bd1658f/conda/conda_build_config.yaml#L6-L7)
```
cadquery:
    - master
```

I thought this was sufficient but it turns out the version needed pinning in the meta,yml as well

```
  run:
    - cadquery==master
```
