### PR TITLE
using cadquery version in config

### DIFF
--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -1,3 +1,5 @@
 python:
     - 3.9
     - 3.8
+cadquery:
+    - master

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - setuptools
   run:
     - python {{ python }}
-    - cadquery * master *
+    - cadquery {{ cadquery }}
     - numpy
 
 test:


### PR DESCRIPTION
this PR changes the conda build so that the version of cadquery comes from the config file. This might help match the version of python